### PR TITLE
Simplify zoom and snap calculations, remove TextFloat

### DIFF
--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -70,7 +70,6 @@ public:
 	void saveSettings( QDomDocument& doc, QDomElement& element ) override;
 	void loadSettings( const QDomElement& element ) override;
 
-	IntModel* zoomingLinearModelSlider() const;
 	ComboBoxModel *snappingModel() const;
 	float getSnapSize() const;
 	QString getSnapSizeString() const;
@@ -116,11 +115,13 @@ private slots:
 
 private:
 	void keyPressEvent( QKeyEvent * ke ) override;
-	void keyReleaseEvent(QKeyEvent* ke) override;
 	void wheelEvent( QWheelEvent * we ) override;
 
 	bool allowRubberband() const override;
 	bool knifeMode() const override;
+
+	int calculatePixelsPerBar() const;
+	int calculateZoomSliderValue(int pixelsPerBar) const;
 
 	int trackIndexFromSelectionPoint(int yPos);
 	int indexOfTrackView(const TrackView* tv);
@@ -142,8 +143,7 @@ private:
 
 	PositionLine * m_positionLine;
 
-	IntModel* m_zoomingLinearModel;
-	int m_zoomingLogValue;
+	IntModel* m_zoomingModel;
 	ComboBoxModel* m_snappingModel;
 	bool m_proportionalSnap;
 
@@ -158,15 +158,14 @@ private:
 	QPoint m_mousePos;
 	int m_rubberBandStartTrackview;
 	TimePos m_rubberbandStartTimePos;
-	int m_currentZoomingValue;
+	int m_rubberbandPixelsPerBar; //!< pixels per bar when selection starts
 	int m_trackHeadWidth;
 	bool m_selectRegion;
-	int m_iniBar = -1;
 
 	friend class SongEditorWindow;
 
 signals:
-	void zoomingValueChanged( float );
+	void pixelsPerBarChanged(float);
 } ;
 
 
@@ -198,10 +197,6 @@ protected slots:
 
 	void updateSnapLabel();
 
-	void showZoomingSliderFloat();
-	void updateZoomingSliderFloat(int new_val);
-	void hideZoomingSliderFloat();
-
 signals:
 	void playTriggered();
 	void resized();
@@ -224,8 +219,6 @@ private:
 
 	QAction* m_insertBarAction;
 	QAction* m_removeBarAction;
-
-	TextFloat * m_zoomStatus;
 };
 
 } // namespace gui

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -125,7 +125,7 @@ ClipView::ClipView( Clip * clip,
 
 	connect( m_clip, SIGNAL(lengthChanged()),
 			this, SLOT(updateLength()));
-	connect(getGUI()->songEditor()->m_editor->zoomingLinearModelSlider(), SIGNAL(dataChanged()), this,	SLOT(updateLength()));
+	connect(getGUI()->songEditor()->m_editor, &SongEditor::pixelsPerBarChanged, this, &ClipView::updateLength);
 	connect( m_clip, SIGNAL(positionChanged()),
 			this, SLOT(updatePosition()));
 	connect( m_clip, SIGNAL(destroyedClip()), this, SLOT(close()));
@@ -314,8 +314,7 @@ void ClipView::updateLength()
 	}
 	else
 	{
-		// 3 is the minimun width needed to paint a clip
-		setFixedWidth(std::max(static_cast<int>(m_clip->length() * pixelsPerBar() / TimePos::ticksPerBar() + 1), 3));
+		setFixedWidth(static_cast<int>(m_clip->length() * pixelsPerBar() / TimePos::ticksPerBar() + 1));
 	}
 	m_trackView->trackContainerView()->update();
 }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -542,7 +542,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 
 void SongEditor::wheelEvent( QWheelEvent * we )
 {
-	if (we->modifiers() & Qt::ControlModifier)
+	if ((we->modifiers() & Qt::ControlModifier) && (position(we).x() > m_trackHeadWidth))
 	{
 		int x = position(we).x() - m_trackHeadWidth;
 		// bar based on the mouse x-position where the scroll wheel was used

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -40,6 +40,11 @@
 namespace lmms::gui
 {
 
+namespace
+{
+	static const int MIN_BAR_LABEL_DISTANCE = 35;
+}
+
 
 QPixmap * TimeLineWidget::s_posMarkerPixmap = nullptr;
 
@@ -271,12 +276,14 @@ void TimeLineWidget::paintEvent( QPaintEvent * )
 	int const x = m_xOffset + s_posMarkerPixmap->width() / 2 -
 			( ( static_cast<int>( m_begin * m_ppb ) / TimePos::ticksPerBar() ) % static_cast<int>( m_ppb ) );
 
+	// Double the interval between bar numbers until they are far enough appart
+	int barLabelInterval = 1;
+	while (barLabelInterval * m_ppb < MIN_BAR_LABEL_DISTANCE) { barLabelInterval *= 2; }
+
 	for( int i = 0; x + i * m_ppb < width(); ++i )
 	{
 		++barNumber;
-		// round m_ppb to the nearest power of two
-		const float ppbP2 = pow(2, round(log2(m_ppb)));
-		if ((barNumber - 1) % std::max(1l, std::lround((1.0f / 3.0f) * TimePos::ticksPerBar() / ppbP2)) == 0)
+		if ((barNumber - 1) % barLabelInterval == 0)
 		{
 			const int cx = x + qRound( i * m_ppb );
 			p.setPen( barLineColor );


### PR DESCRIPTION
Here are some suggested changes to make the zoom logic more easy to understand. I also removed the TextFloat... I'll explain why in the comments. If you decide it's ok you can merge it, otherwise you may handpick the parts you like.